### PR TITLE
BREAKING CHANGE: base64 encoding for data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phase.dev/phase-js",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "JS/TS Client SDK for Phase",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -68,6 +68,8 @@ const encryptRaw = async (plaintext: String, key: Uint8Array) => {
 export const encryptString = async (plaintext: string, key: Uint8Array) => {
   await _sodium.ready;
   const sodium = _sodium;
-
-  return sodium.to_hex(await encryptRaw(sodium.from_string(plaintext), key));
+  return sodium.to_base64(
+    await encryptRaw(sodium.from_string(plaintext), key),
+    sodium.base64_variants.ORIGINAL
+  );
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -34,7 +34,9 @@ describe("Phase", () => {
 
     // Check if the one-time public key and ciphertext are valid hex strings
     expect(segments[2]).toMatch(/^[0-9a-f]+$/);
-    expect(segments[3]).toMatch(/^[0-9a-f]+$/);
+    expect(segments[3]).toMatch(
+      /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+    );
   });
 
   test("Check if Phase encrypt always produces ciphertexts (ph:*) of the same length for the same plaintext", async () => {


### PR DESCRIPTION
## Description

Replaces hex encoding with base64 to optimize the size of ciphertext strings.

## Changes

-  Updated the `encryptString`  util to use b64 encoding instead of hex
-  Updated the regex in the tests to validate that the ciphertext is a base64 string
-  Bumped the package version to `2.0.0`

